### PR TITLE
feat: Add Q&A entry for ignoring files/folders in Cody

### DIFF
--- a/answers.json
+++ b/answers.json
@@ -87,4 +87,9 @@
   "url": "https://community.sourcegraph.com/t/is-there-a-status-board-for-cody/2537",
   "title": "Is there a status board for Cody?",
   "answer": "Yes, Sourcegraph maintains a status page for monitoring Cody and other services. You can check the status page at 'Sourcegraph Status' which shows maintenance events and service availability. During outages, Sourcegraph also posts announcements about scheduled maintenance that may affect service here: https://sourcegraphstatus.com/"
+},
+{
+  "url": "https://community.sourcegraph.com/t/how-to-ignore-files-folders/2622",
+  "title": "How to ignore files/folders in Cody",
+  "answer": "Currently, Cody does not have a built-in file/folder ignore feature for JetBrains IDEs. While the documentation mentions an ignore feature for Enterprise users, this is not available for Pro users at this time. The feature has been requested and tagged for the product team's consideration. Pro users seeking similar functionality should monitor future updates as this has been identified as a desired feature."
 }]


### PR DESCRIPTION
This commit introduces a new question and answer entry to `answers.json` to address the ability to ignore files and folders within Cody, specifically for JetBrains IDEs.

The changes include:

- Added a Q&A entry explaining the current lack of a built-in file/folder ignore feature for JetBrains IDEs in Cody for Pro users. It clarifies that while documentation mentions an ignore feature for Enterprise users, this functionality is not yet available for Pro users. The entry also notes that the feature has been requested and is under consideration by the product team, advising users to monitor future updates.