### PR TITLE
feat: Add Q&A entry for customizing Cody in Visual Studio

### DIFF
--- a/answers.json
+++ b/answers.json
@@ -92,4 +92,9 @@
   "url": "https://community.sourcegraph.com/t/how-to-ignore-files-folders/2622",
   "title": "How to ignore files/folders in Cody",
   "answer": "Currently, Cody does not have a built-in file/folder ignore feature for JetBrains IDEs. While the documentation mentions an ignore feature for Enterprise users, this is not available for Pro users at this time. The feature has been requested and tagged for the product team's consideration. Pro users seeking similar functionality should monitor future updates as this has been identified as a desired feature."
+},
+{
+  "url": "https://community.sourcegraph.com/t/how-to-customize-cody/2651",
+  "title": "How to customize Cody in Visual Studio",
+  "answer": "For customizing Cody in Visual Studio, use 'cody.chat.preInstruction' instead of 'instructions' in your configuration file. The Visual Studio extension is still in experimental phase, so some features may not work as expected. When configuring Cody, ensure you're using the correct configuration keys as they differ between IDE extensions."
 }]


### PR DESCRIPTION
This commit introduces a new question and answer entry to `answers.json` to guide users on how to customize Cody in Visual Studio.

The changes include:

- Added a Q&A entry explaining how to customize Cody in Visual Studio using `cody.chat.preInstruction` instead of `instructions` in the configuration file. It also mentions that the Visual Studio extension is still in the experimental phase and that configuration keys may differ between IDE extensions.